### PR TITLE
Update Dockerfile to use multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,17 @@
-FROM golang:1.22
+FROM golang:1.22 AS build-stage
 
-WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . ./
 
 RUN CGO_ENABLED=0 GOOS=linux go build -o /frigabun
+
+FROM gcr.io/distroless/static-debian11 AS build-release-stage
+
+COPY --from=build-stage /frigabun /frigabun
+
+WORKDIR /app
 EXPOSE 9595
 
 CMD ["/frigabun"]


### PR DESCRIPTION
This reduces the image size from 1.04GB to 31.3MB, which makes it easier to stay within cloud provider free tiers.