### PR TITLE
Update porkbun API host in sample config

### DIFF
--- a/config.sample.toml
+++ b/config.sample.toml
@@ -16,7 +16,7 @@ apiKey = ""
 
 [porkbun]
 enabled = false
-baseUrl = "https://porkbun.com/api/json/v3"
+baseUrl = "https://api.porkbun.com/api/json/v3"
 apiKey = ""
 secretApiKey = ""
 ttl = 1800


### PR DESCRIPTION
As per [1] and the advisory email released yesterday:
```
CRITICAL UPDATE DETAILS

Type: API Hostname Change

Old Value: porkbun.com

New Value: api.porkbun.com

Deadline: 2024-12-01 00:00:00 UTC
```

[1] https://porkbun.com/api/json/v3/documentation#apiHost